### PR TITLE
Move GitHub recipes in its own subpackage

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ from fastapi import FastAPI
 from github import Auth, Github
 
 from fastgithub import GithubWebhookHandler, SignatureVerificationSHA256, webhook_router
-from fastgithub.recipes.github import AutoCreatePullRequest, LabelFromCommit
+from fastgithub.recipes.github import AutoCreatePullRequest, LabelsFromCommits
 
 signature_verification = SignatureVerificationSHA256(secret="mysecret")  # noqa: S106
 webhook_handler = GithubWebhookHandler(signature_verification)
@@ -96,7 +96,7 @@ webhook_handler = GithubWebhookHandler(signature_verification)
 github = Github(auth=Auth.Token(os.environ["GITHUB_TOKEN"]))
 
 webhook_handler.listen("push", [AutoCreatePullRequest(github)])
-webhook_handler.listen("pull_request", [LabelFromCommit(github)])
+webhook_handler.listen("pull_request", [LabelsFromCommits(github)])
 
 
 app = FastAPI()

--- a/examples/github_app.py
+++ b/examples/github_app.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 from github import Auth, Github
 
 from fastgithub import GithubWebhookHandler, SignatureVerificationSHA256, webhook_router
-from fastgithub.recipes.github import AutoCreatePullRequest, LabelFromCommit
+from fastgithub.recipes.github import AutoCreatePullRequest, LabelsFromCommits
 
 signature_verification = SignatureVerificationSHA256(secret="mysecret")  # noqa: S106
 webhook_handler = GithubWebhookHandler(signature_verification)
@@ -13,7 +13,7 @@ webhook_handler = GithubWebhookHandler(signature_verification)
 github = Github(auth=Auth.Token(os.environ["GITHUB_TOKEN"]))
 
 webhook_handler.listen("push", [AutoCreatePullRequest(github)])
-webhook_handler.listen("pull_request", [LabelFromCommit(github)])
+webhook_handler.listen("pull_request", [LabelsFromCommits(github)])
 
 
 app = FastAPI()

--- a/src/fastgithub/recipes/__init__.py
+++ b/src/fastgithub/recipes/__init__.py
@@ -1,3 +1,3 @@
-"""A package that handles hook operation."""
+"""A package that handles hook operations."""
 
 from ._base import GithubRecipe, Recipe

--- a/src/fastgithub/recipes/github/__init__.py
+++ b/src/fastgithub/recipes/github/__init__.py
@@ -1,0 +1,4 @@
+"""A package that handles GitHub hook operations."""
+
+from .autocreate_pr import AutoCreatePullRequest
+from .labels_from_commits import LabelsFromCommits

--- a/src/fastgithub/recipes/github/autocreate_pr.py
+++ b/src/fastgithub/recipes/github/autocreate_pr.py
@@ -1,9 +1,8 @@
 from github.GithubException import GithubException
 
 from fastgithub.helpers.github import GithubHelper
+from fastgithub.recipes._base import GithubRecipe
 from fastgithub.types import Payload
-
-from ._base import GithubRecipe
 
 
 class AutoCreatePullRequest(GithubRecipe):
@@ -31,24 +30,3 @@ class AutoCreatePullRequest(GithubRecipe):
             except GithubException as ex:
                 if ex.status != 422:
                     raise ex
-
-
-LABEL_CONFIG: dict[str, list[str]] = {
-    "#nodraft": ["nodraft"],
-    "#fast": ["nodraft", "automerge", "autoapprove"],
-    "#release": ["nodraft", "automerge", "autorelease"],
-    "#furious": ["nodraft", "automerge", "autoapprove", "autorelease"],
-}
-
-
-class LabelFromCommit(GithubRecipe):
-    def __call__(
-        self,
-        payload: Payload,
-        labels_config: dict[str, list[str]] = LABEL_CONFIG,
-    ):
-        gh = GithubHelper(self.github, payload["repository"]["full_name"])
-        if not gh.rate_status.too_low():
-            pr = gh.repo.get_pull(payload["number"])
-            if labels := gh.extract_labels_from_pr(pr, labels_config):
-                gh.add_labels_to_pr(pr, labels)

--- a/src/fastgithub/recipes/github/labels_from_commits.py
+++ b/src/fastgithub/recipes/github/labels_from_commits.py
@@ -1,0 +1,23 @@
+from fastgithub.helpers.github import GithubHelper
+from fastgithub.recipes._base import GithubRecipe
+from fastgithub.types import Payload
+
+LABEL_CONFIG: dict[str, list[str]] = {
+    "#nodraft": ["nodraft"],
+    "#fast": ["nodraft", "automerge", "autoapprove"],
+    "#release": ["nodraft", "automerge", "autorelease"],
+    "#furious": ["nodraft", "automerge", "autoapprove", "autorelease"],
+}
+
+
+class LabelsFromCommits(GithubRecipe):
+    def __call__(
+        self,
+        payload: Payload,
+        labels_config: dict[str, list[str]] = LABEL_CONFIG,
+    ):
+        gh = GithubHelper(self.github, payload["repository"]["full_name"])
+        if not gh.rate_status.too_low():
+            pr = gh.repo.get_pull(payload["number"])
+            if labels := gh.extract_labels_from_pr(pr, labels_config):
+                gh.add_labels_to_pr(pr, labels)


### PR DESCRIPTION
# What does this PR do?

Move GitHub recipes in its own subpackage

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit install` or `pre-commit run -a` command?
