### PR TITLE
feat: create a PR as draft by default

### DIFF
--- a/src/fastgithub/recipes/github/autocreate_pr.py
+++ b/src/fastgithub/recipes/github/autocreate_pr.py
@@ -18,7 +18,7 @@ class AutoCreatePullRequest(GithubRecipe):
         base_branch: str | None = None,
         title: str | None = None,
         body: str = "Created by FastGitHub",
-        as_draft: bool = False,
+        as_draft: bool = True,
     ):
         gh = GithubHelper(self.github, repo_fullname=payload["repository"]["full_name"])
         gh.raise_for_rate_excess()


### PR DESCRIPTION
# What does this PR do?

This PR creates a PR as draft by default when a new branch is pushed to the remote repository.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit install` or `pre-commit run -a` command?
